### PR TITLE
slowdown fixed

### DIFF
--- a/src/composition/composition.cpp
+++ b/src/composition/composition.cpp
@@ -178,3 +178,29 @@ int composition::SetRng(randmt_t *rng)
 
   return 0;
 }
+int composition::ReduceMap(vector<string> used_phases) {
+	phase *Ph_new = new phase[used_phases.size()];
+	phase_map PhaseMap_new;
+	phase_map::iterator it;
+
+	NPhases = used_phases.size();
+
+	for (int i = 0 ; i < used_phases.size() ; i++) {
+		it = PhaseMap.find(used_phases.at(i));
+		if (it==PhaseMap.end()) {
+      			throw xrmc_exception(string("Phase ") + used_phases.at(i)
+                           + " not found in phase map\n");
+		}
+		
+		Ph_new[i] = Ph[it->second];
+		PhaseMap_new.insert(phase_map_pair(used_phases.at(i), i));
+	}
+
+	delete []Ph;
+	Ph = Ph_new;
+	PhaseMap.clear();
+	
+	for (it = PhaseMap_new.begin(); it != PhaseMap_new.end() ; it++) {
+		PhaseMap.insert(phase_map_pair(it->first, it->second));
+	}
+}

--- a/src/composition/xrmc_composition.h
+++ b/src/composition/xrmc_composition.h
@@ -87,6 +87,7 @@ class composition : public xrmc_device
   int Delta(double E); // Evaluates the delta coefficient of each phase
   virtual composition *Clone(string dev_name);
   virtual int SetRng(randmt_t *rng);
+  int ReduceMap(vector<string> used_phases);
 };
 
 #endif

--- a/src/geom3d/geom3d.cpp
+++ b/src/geom3d/geom3d.cpp
@@ -31,6 +31,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 using namespace std;
 using namespace xrmc_algo;
 
+bool geom3d::MapReduced = false;
 // destructor
 geom3d::~geom3d() {
   for (int i=0; i<NQVol; i++) {
@@ -104,6 +105,12 @@ int geom3d::LinkInputDevice(string command, xrmc_device *dev_pt)
 int geom3d::RunInit()
 {
 
+  //clean up the phases
+  if (!MapReduced) {
+  	Comp->ReduceMap(used_phases);
+	MapReduced = true;
+  }
+
   for(int iqv=0; iqv<NQVol; iqv++) { // loop on 3d objects
     for(int iq=0; iq<QVol[iqv].NQuadr; iq++) { // loop on quadrics delimiting
                                                // the 3d object
@@ -123,6 +130,7 @@ int geom3d::RunInit()
 
     }
     string s_ph_in = QVol[iqv].PhaseInName;
+
     // check if the phase name is present in phase map
     phase_map::iterator it = Comp->PhaseMap.find(s_ph_in);
     // if not display error and exit

--- a/src/geom3d/loadgeom3d.cpp
+++ b/src/geom3d/loadgeom3d.cpp
@@ -24,6 +24,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <iostream>
 #include <string>
+#include <algorithm>
 #include "xrmc.h"
 #include "xrmc_geom3d.h"
 #include "xrmc_exception.h"
@@ -88,7 +89,14 @@ int geom3d::Load(istream &fs)
       cout << "\tPhase Inside: " << QVol[NQVol].PhaseInName << endl;
       cout << "\tPhase Outside: " << QVol[NQVol].PhaseOutName << endl;
       cout << "\tNum. of quadrics: " << QVol[NQVol].NQuadr << endl;
-      
+     
+      if (find(used_phases.begin(), used_phases.end(), s_ph_in) == used_phases.end()) {
+      	used_phases.push_back(s_ph_in);
+      }
+      if (find(used_phases.begin(), used_phases.end(), s_ph_out) == used_phases.end()) {
+      	used_phases.push_back(s_ph_out);
+      }
+
       for(i=0; i<n_quadr; i++) { // loop on quadrics delimiting the 3d object
 	GetToken(fs, s);
 	qname = s; // quadric name

--- a/src/geom3d/xrmc_geom3d.h
+++ b/src/geom3d/xrmc_geom3d.h
@@ -25,6 +25,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef GEOM3DH
 #define GEOM3DH
 #include <string>
+#include <vector>
 #include "xrmc_device.h"
 #include "xrmc_math.h"
 #include "xrmc_composition.h"
@@ -120,6 +121,8 @@ class geom3d : public xrmc_device
   std::string QArrName;
   composition *Comp; // input composition device
   std::string CompName;
+  vector<string> used_phases;
+  static bool MapReduced;
 
   int NQVol; // number of 3d objects used in the geometric description
   int MaxNQVol; // maximum number of 3d objects in the geometric description


### PR DESCRIPTION
had to do with NIST database addition: I didn't realize that at any given moment the complete Comp.Ph array would be used for the Mu calculation: so the slowdown was because the code was calculating attenuation coefficients for all 180 NIST compounds + the user defined ones.

I have introduced code that fixes this: in geom3d's RunInit I am now calling ReduceMap, which will shrink the Ph array to what is actually need based on the required phases.
