### PR TITLE
segfault avoided at end of execution

### DIFF
--- a/src/main/xrmc.h
+++ b/src/main/xrmc.h
@@ -39,7 +39,7 @@ using namespace std;
 class xrmc
 {
  public:
-  ~xrmc() { DeleteDevices(); }// destructor
+  //~xrmc() { DeleteDevices(); }// destructor
   int Run(string file_name); // method for running the simulation
  private:
   xrmc_device_map DeviceMap; // map of devices used by the simulation


### PR DESCRIPTION
all delete/free now happens inside of Acquisition

Not entirely sure this is the best way but I think that DeleteDevices wasn't doing a complete job anyway because of all the clones.
