### PR TITLE
SPEC file: replace == with =

### DIFF
--- a/xrmc.spec.in
+++ b/xrmc.spec.in
@@ -17,7 +17,7 @@ XRMC is a Monte Carlo program for accurate simulation of X-ray imaging and spect
 
 %package devel
 Summary: A tool for the simulation of X-ray imaging and spectroscopy experiments: development package
-Requires: xraylib-devel >= 3.0.0 xmimsim-devel >= 3.1 libstdc++-devel xrmc == @VERSION@ xrmc-xmimsim == @VERSION@
+Requires: xraylib-devel >= 3.0.0 xmimsim-devel >= 3.1 libstdc++-devel %{name} = %{version} %{name}-xmimsim = %{version}
 
 %description devel
 XRMC is a Monte Carlo program for accurate simulation of X-ray imaging and spectroscopy experiments in heterogeneous samples. The use of the Monte Carlo method makes the code suitable for the detailed simulation of complex experiments on generic samples. Variance reduction techniques are used for reducing considerably the computation time compared to general purpose Monte Carlo programs. The program is written in c++ and has been tested on Linux, Mac OS X and MS Windows platforms.
@@ -26,7 +26,7 @@ This package contains the headers and static libraries, as well as a pkg-config 
 
 %package xmimsim
 Summary: A tool for the simulation of X-ray imaging and spectroscopy experiments: XMI-MSIM plugin
-Requires: xrmc == @VERSION@ xmimsim >= 6.0
+Requires: %{name} = %{version} xmimsim >= 6.0
 
 %description xmimsim 
 XRMC is a Monte Carlo program for accurate simulation of X-ray imaging and spectroscopy experiments in heterogeneous samples. The use of the Monte Carlo method makes the code suitable for the detailed simulation of complex experiments on generic samples. Variance reduction techniques are used for reducing considerably the computation time compared to general purpose Monte Carlo programs. The program is written in c++ and has been tested on Linux, Mac OS X and MS Windows platforms.


### PR DESCRIPTION
This was apparently never supported by rpmbuild, and the latest version on Fedora 27 appears to process them incorrectly resulting in broken rpm files...