### PR TITLE
Add Travis-CI and AppVeyor support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,3 +63,7 @@ notifications:
       - Tom.Schoonjans@me.com
     on_success: never
     on_failure: always
+
+branches:
+  only:
+    - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ env:
 
 matrix:
   include:
-
     - os: linux
       dist: trusty
       addons:
@@ -19,6 +18,23 @@ matrix:
               key_url: 'http://xmi-apt.tomschoonjans.eu/xmi.packages.key'
           packages:
             - libxrl7-dev
+    - os: osx
+      sudo: required
+      env: CC='/usr/local/opt/llvm/bin/clang' CXX='/usr/local/opt/llvm/bin/clang++'
+
+before_install:
+  - |
+    if [ "$TRAVIS_OS_NAME" == "osx" ] ; then
+      brew cask uninstall --force oclint
+      brew uninstall --force --ignore-dependencies $(brew list) || exit 1
+      brew update || exit 1
+      brew cleanup -s || exit 1
+      rm -rf $(brew --cache) || exit 1
+      brew install pkg-config gettext autoconf automake libtool homebrew/science/xraylib || exit 1
+      brew install llvm || exit 1
+      brew cleanup -s || exit 1
+      rm -rf $(brew --cache) || exit 1
+    fi
 
 script:
   - autoreconf -fi || exit 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,10 @@ matrix:
             - libgsl0-dev # this line shouldn't be here and is an error in the fgsl debbuild files...
     - os: osx
       sudo: required
-      env: CC='/usr/local/opt/llvm/bin/clang' CXX='/usr/local/opt/llvm/bin/clang++'
+      env: BREW_EXTRA='llvm' CC='/usr/local/opt/llvm/bin/clang' CXX='/usr/local/opt/llvm/bin/clang++'
+    - os: osx
+      sudo: required
+      env: BREW_EXTRA='gcc@7' CC='/usr/local/opt/gcc@7/bin/gcc-7' CXX='/usr/local/opt/gcc@7/bin/g++-7'
 
 before_install:
   - |
@@ -42,7 +45,7 @@ before_install:
       brew cleanup -s || exit 1
       rm -rf $(brew --cache) || exit 1
       brew install pkg-config gettext autoconf automake libtool homebrew/science/xraylib || exit 1
-      brew install llvm || exit 1
+      brew install $BREW_EXTRA || exit 1
       brew cleanup -s || exit 1
       rm -rf $(brew --cache) || exit 1
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,6 +61,7 @@ notifications:
   email:
     recipients:
       - Tom.Schoonjans@me.com
+      - golosio@unica.it
     on_success: never
     on_failure: always
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,35 @@
+language: generic
+
+env:
+  global:
+    - CXXFLAGS="-Wno-deprecated -Wno-deprecated-declarations -Wimplicit  -Wimplicit-function-declaration  -Wimplicit-int"
+    - CFLAGS="-Wno-deprecated -Wno-deprecated-declarations -Wimplicit  -Wimplicit-function-declaration  -Wimplicit-int"
+    - LD_LIBRARY_PATH='/usr/local/lib'
+    - PKG_CONFIG_PATH='/usr/local/lib/pkgconfig'
+
+matrix:
+  include:
+
+    - os: linux
+      dist: trusty
+      addons:
+        apt:
+          sources:
+            - sourceline: 'deb [arch=amd64] http://xmi-apt.tomschoonjans.eu/ubuntu trusty stable'
+              key_url: 'http://xmi-apt.tomschoonjans.eu/xmi.packages.key'
+          packages:
+            - libxrl7-dev
+
+script:
+  - autoreconf -fi || exit 1
+  - ./configure || exit 1
+  - make || exit 1
+  - make check || exit 1
+  - if [ "$TRAVIS_OS_NAME" == "linux" ] ; then make distcheck || exit 1 ; fi
+
+notifications:
+  email:
+    recipients:
+      - Tom.Schoonjans@me.com
+    on_success: never
+    on_failure: always

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,17 @@ matrix:
               key_url: 'http://xmi-apt.tomschoonjans.eu/xmi.packages.key'
           packages:
             - libxrl7-dev
+    - os: linux
+      dist: trusty
+      env: WITH_XMI_MSIM='yes' EXTRA_ARGS='--enable-xmi-msim'
+      addons:
+        apt:
+          sources:
+            - sourceline: 'deb [arch=amd64] http://xmi-apt.tomschoonjans.eu/ubuntu trusty stable'
+              key_url: 'http://xmi-apt.tomschoonjans.eu/xmi.packages.key'
+          packages:
+            - libxmimsim0-dev
+            - libgsl0-dev # this line shouldn't be here and is an error in the fgsl debbuild files...
     - os: osx
       sudo: required
       env: CC='/usr/local/opt/llvm/bin/clang' CXX='/usr/local/opt/llvm/bin/clang++'
@@ -38,10 +49,10 @@ before_install:
 
 script:
   - autoreconf -fi || exit 1
-  - ./configure || exit 1
+  - ./configure ${EXTRA_ARGS} || exit 1
   - make || exit 1
-  - make check || exit 1
-  - if [ "$TRAVIS_OS_NAME" == "linux" ] ; then make distcheck || exit 1 ; fi
+  - if [ "$WITH_XMI_MSIM" != "yes" ] ; then make check || exit 1 ; fi
+  - if [ "$TRAVIS_OS_NAME" == "linux" ] && [ "$WITH_XMI_MSIM" != "yes" ] ; then make distcheck || exit 1 ; fi
 
 notifications:
   email:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,27 @@
+version: 1.0.{build}
+
+environment:
+  matrix:
+    - compiler: msvc_msys2
+      ARCH: x64
+      MSYS2_ARCH: x86_64
+      MSYS2_DIR: msys64
+      MSYSTEM: MINGW64
+    - compiler: msvc_msys2
+      ARCH: x86
+      MSYS2_ARCH: i686
+      MSYS2_DIR: msys64
+      MSYSTEM: MINGW32
+
+before_build:
+    - set PATH=C:\%MSYS2_DIR%\%MSYSTEM%\bin;C:\%MSYS2_DIR%\usr\bin;%PATH%
+    - bash -lc "for i in {1..3}; do update-core && break || sleep 15; done"
+    - bash -lc "for i in {1..3}; do pacman --noconfirm -Su mingw-w64-%MSYS2_ARCH%-{gcc,libtool} automake autoconf make wget tar && break || sleep 15; done"
+    - bash -lc "wget https://xraylib.tomschoonjans.eu/xraylib-3.3.0.tar.gz && tar xvfz xraylib-3.3.0.tar.gz && cd xraylib-3.3.0 && ./configure --prefix=/usr/local --disable-all-bindings && make && make check && make install && cd .."
+
+build_script:
+    - cd %APPVEYOR_BUILD_FOLDER%
+    - echo %cd%
+    - dir
+    - bash -lc "cd $APPVEYOR_BUILD_FOLDER && exec 0</dev/null && ACLOCAL_PATH=/usr/local/share/aclocal autoreconf -fi && PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/usr/local/share/pkgconfig ./configure && make && make check && make distcheck"
+

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,3 +25,6 @@ build_script:
     - dir
     - bash -lc "cd $APPVEYOR_BUILD_FOLDER && exec 0</dev/null && ACLOCAL_PATH=/usr/local/share/aclocal autoreconf -fi && PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/usr/local/share/pkgconfig ./configure && make && make check && make distcheck"
 
+branches:
+  only:
+    - master

--- a/examples/anisotropicsource/detector.dat
+++ b/examples/anisotropicsource/detector.dat
@@ -17,7 +17,7 @@ PhotonNum 1			; Multiplicity of simulated events per pixel
 RandomPixelFlag 1		; Enable random point on pixels (0/1)
 PoissonFlag 0			; Enable Poisson statistic on pix. counts (0/1)
 RoundFlag 0			; Round pixel counts to integer (0/1)
-HeaderFlag 0                    ; Use header in output file (0/1)
+HeaderFlag 1                    ; Use header in output file (0/1)
 PixelType 0			; Pixel content type:
 				; 0: fluence,      1: energy fluence,
 				; 2: fluence(E),   3: energy fluence(E)

--- a/examples/beamsource/detector.dat
+++ b/examples/beamsource/detector.dat
@@ -16,7 +16,7 @@ PhotonNum 1			; Multiplicity of simulated events per pixel
 RandomPixelFlag 1		; Enable random point on pixels (0/1)
 PoissonFlag 0			; Enable Poisson statistic on pix. counts (0/1)
 RoundFlag 0			; Round pixel counts to integer (0/1)
-HeaderFlag 0                    ; Use header in output file (0/1)
+HeaderFlag 1                    ; Use header in output file (0/1)
 PixelType 0			; Pixel content type:
 				; 0: fluence,      1: energy fluence,
 				; 2: fluence(E),   3: energy fluence(E)

--- a/examples/cylind_shell/detector.dat
+++ b/examples/cylind_shell/detector.dat
@@ -16,7 +16,7 @@ PhotonNum 1			; Multiplicity of simulated events per pixel
 RandomPixelFlag 1		; Enable random point on pixels (0/1)
 PoissonFlag 0			; Enable Poisson statistic on pix. counts (0/1)
 RoundFlag 0			; Round pixel counts to integer (0/1)
-HeaderFlag 0                    ; Use header in output file (0/1)
+HeaderFlag 1                    ; Use header in output file (0/1)
 PixelType 0			; Pixel content type:
 				; 0: fluence,      1: energy fluence,
 				; 2: fluence(E),   3: energy fluence(E)

--- a/examples/fluor_layers/detector_0deg.dat
+++ b/examples/fluor_layers/detector_0deg.dat
@@ -16,7 +16,7 @@ PhotonNum 2000			; Multiplicity of simulated events per pixel
 RandomPixelFlag 1		; Enable random point on pixels (0/1)
 PoissonFlag 0			; Enable poisson statistic on pix. counts (0/1)
 RoundFlag 0 			; Round pixel counts to integer (0/1)
-HeaderFlag 0                    ; Use header in output file (0/1)
+HeaderFlag 1                    ; Use header in output file (0/1)
 ;AsciiFlag 0			; binary(0) or ascii(1) file format
 PixelType 2	   		; Pixel content type:
 	  			; 0: fluence, 1: energy fluence,

--- a/examples/materials/detector.dat
+++ b/examples/materials/detector.dat
@@ -16,7 +16,7 @@ PhotonNum 1			; Multiplicity of simulated events per pixel
 RandomPixelFlag 1		; Enable random point on pixels (0/1)
 PoissonFlag 0			; Enable Poisson statistic on pix. counts (0/1)
 RoundFlag 0			; Round pixel counts to integer (0/1)
-HeaderFlag 0                    ; Use header in output file (0/1)
+HeaderFlag 1                    ; Use header in output file (0/1)
 PixelType 0			; Pixel content type:
 				; 0: fluence,      1: energy fluence,
 				; 2: fluence(E),   3: energy fluence(E)

--- a/examples/phasecontrast/phcdetector.dat
+++ b/examples/phasecontrast/phcdetector.dat
@@ -17,7 +17,7 @@ PhotonNum 1			; Multiplicity of simulated events per pixel
 RandomPixelFlag 1		; Enable random point on pixels (0/1)
 PoissonFlag 0			; Enable Poisson statistic on pix. counts (0/1)
 RoundFlag 0			; Round pixel counts to integer (0/1)
-HeaderFlag 0                    ; Use header in output file (0/1)
+HeaderFlag 1                    ; Use header in output file (0/1)
 PixelType 0			; Pixel content type:
 				; 0: fluence,      1: energy fluence,
 				; 2: fluence(E),   3: energy fluence(E)

--- a/examples/quadrics/detector.dat
+++ b/examples/quadrics/detector.dat
@@ -16,7 +16,7 @@ PhotonNum 1			; Multiplicity of simulated events per pixel
 RandomPixelFlag 1		; Enable random point on pixels (0/1)
 PoissonFlag 0			; Enable Poisson statistic on pix. counts (0/1)
 RoundFlag 0			; Round pixel counts to integer (0/1)
-HeaderFlag 0                    ; Use header in output file (0/1)
+HeaderFlag 1                    ; Use header in output file (0/1)
 PixelType 0			; Pixel content type:
 				; 0: fluence,      1: energy fluence,
 				; 2: fluence(E),   3: energy fluence(E)

--- a/examples/star1/detector.dat
+++ b/examples/star1/detector.dat
@@ -18,7 +18,7 @@ PhotonNum 1			; Multiplicity of simulated events per pixel
 RandomPixelFlag 1		; Enable random point on pixels (0/1)
 PoissonFlag 0			; Enable Poisson statistic on pix. counts (0/1)
 RoundFlag 0			; Round pixel counts to integer (0/1)
-HeaderFlag 0                    ; Use header in output file (0/1)
+HeaderFlag 1                    ; Use header in output file (0/1)
 PixelType 0			; Pixel content type:
 				; 0: fluence,      1: energy fluence,
 				; 2: fluence(E),   3: energy fluence(E)

--- a/examples/star2/detector.dat
+++ b/examples/star2/detector.dat
@@ -16,7 +16,7 @@ PhotonNum 1			; Multiplicity of simulated events per pixel
 RandomPixelFlag 1		; Enable random point on pixels (0/1)
 PoissonFlag 0			; Enable Poisson statistic on pix. counts (0/1)
 RoundFlag 0			; Round pixel counts to integer (0/1)
-HeaderFlag 0                    ; Use header in output file (0/1)
+HeaderFlag 1                    ; Use header in output file (0/1)
 PixelType 0			; Pixel content type:
 				; 0: fluence,      1: energy fluence,
 				; 2: fluence(E),   3: energy fluence(E)

--- a/examples/wheel/detector.dat
+++ b/examples/wheel/detector.dat
@@ -16,7 +16,7 @@ PhotonNum 1			; Multiplicity of simulated events per pixel
 RandomPixelFlag 1		; Enable random point on pixels (0/1)
 PoissonFlag 0			; Enable Poisson statistic on pix. counts (0/1)
 RoundFlag 0			; Round pixel counts to integer (0/1)
-HeaderFlag 0                    ; Use header in output file (0/1)
+HeaderFlag 1                    ; Use header in output file (0/1)
 PixelType 0			; Pixel content type:
 				; 0: fluence,      1: energy fluence,
 				; 2: fluence(E),   3: energy fluence(E)

--- a/src/composition/composition.cpp
+++ b/src/composition/composition.cpp
@@ -198,9 +198,7 @@ int composition::ReduceMap(vector<string> used_phases) {
 
 	delete []Ph;
 	Ph = Ph_new;
-	PhaseMap.clear();
+	PhaseMap = PhaseMap_new;
 	
-	for (it = PhaseMap_new.begin(); it != PhaseMap_new.end() ; it++) {
-		PhaseMap.insert(phase_map_pair(it->first, it->second));
-	}
+	return 0;
 }

--- a/src/geom3d/geom3d.cpp
+++ b/src/geom3d/geom3d.cpp
@@ -31,7 +31,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 using namespace std;
 using namespace xrmc_algo;
 
-bool geom3d::MapReduced = false;
 // destructor
 geom3d::~geom3d() {
   for (int i=0; i<NQVol; i++) {
@@ -61,6 +60,9 @@ geom3d::geom3d(string dev_name) {
   QVolMap = NULL;
   QVol = NULL;
   NQVol = 0;
+
+  MapReduced = false;
+
   SetDevice(dev_name, "geom3d");
 }
 
@@ -213,6 +215,8 @@ geom3d *geom3d::Clone(string dev_name) {
 	  for (int j = 0 ; j < QVol[i].NQuadr ; j++)
 	    clone->QVolMap[i][j] = QVolMap[i][j];
 	}
+	clone->used_phases = used_phases;
+	clone->MapReduced = MapReduced;
 	clone->RunInit();
 	
 	return clone;

--- a/src/geom3d/xrmc_geom3d.h
+++ b/src/geom3d/xrmc_geom3d.h
@@ -123,7 +123,7 @@ class geom3d : public xrmc_device
   composition *Comp; // input composition device
   std::string CompName;
   vector<string> used_phases;
-  static bool MapReduced;
+  bool MapReduced;
 
   int NQVol; // number of 3d objects used in the geometric description
   int MaxNQVol; // maximum number of 3d objects in the geometric description


### PR DESCRIPTION
Hi @golosio,

I have added the necessary configuration files for building XRMC on Travis-CI (Linux and macOS) and AppVeyor (Windows)
This will allow for testing code that is being added to pull requests.

On Linux it will test using gcc, both with and without using XMI-MSIM support.
On macOS it will build once with clang and once with gcc. Building with clang actually allowed me to find a bug!
On Windows it will build with gcc, both in 64-bit mode and 32-bit mode.

If you would look to see the latest build results:

https://travis-ci.org/tschoonj/xrmc/builds/305220875
https://ci.appveyor.com/project/tschoonj/xrmc


In order for this work for new pull requests, you will need to do some things on the Travis-CI and AppVeyor websites though (I cannot do this for you unfortunately).
For Travis-CI: do steps 1. and 2. as explained at https://docs.travis-ci.com/user/getting-started/
For AppVeyor: do steps 1. and 2. as explained at https://www.appveyor.com/docs/

Make sure you always use Github authentication, there is no need to create new accounts.

Let me know if you need any help!

Best,

Tom